### PR TITLE
Removed Cython & added mpi4py warning

### DIFF
--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -13,6 +13,7 @@ try:
     from mpi4py import MPI
 except ImportError:
     from . import nompi4py as MPI
+    print("WARNING: no mpi4py installed. Parallel jobs will not run correctly")
 
 try:
     import acor

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,6 @@ except ImportError:
     from distutils.core import setup
     from distutils.extension import Extension
 
-from Cython.Build import cythonize
-
 
 if sys.argv[-1] == "publish":
     os.system("python setup.py sdist upload")
@@ -40,8 +38,4 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
     ]
-    # For Cython code, include the following modules
-    #,
-    #ext_modules = cythonize(Extension('pal2.jitterext', ['pal2/jitterext.pyx'],
-    #        include_dirs = [numpy.get_include()]))
 )


### PR DESCRIPTION
The Cython dependency was not necessary (setup.py required it).

The no mpi4py warning is perhaps redundant, since setup.py has it as a requirement. But it does not hurt, since PTMCMCSampler can be imported without having been installed.