### PR TITLE
Added note about acor for Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@ MPI enabled Parallel Tempering MCMC code written in Python.
 
 Please visit http://jellis18.github.io/PTMCMCSampler/ for documentation.
 
-In order for the sampler to run correctly with Python 3 kernels the GitHub version of acor needs to be installed. It can be in stalled with:
-```
-pip install git+https://github.com/dfm/acor.git@master
-```
 
 ## Attribution
 
@@ -23,4 +19,16 @@ If you make use of this code, please cite:
   doi          = {10.5281/zenodo.1037579},
   url          = {https://doi.org/10.5281/zenodo.1037579}
 }
+```
+
+## Installation
+
+The PTMCMCSampler is available from PyPI. The easiest way to install is via pip:
+```
+pip install PTMCMCSampler
+```
+### Python 3
+In order for the sampler to run correctly with Python 3 kernels the GitHub version of acor needs to be installed. (Currently the PyPI version is behind the GitHub version.) It can be easily installed with:
+```
+pip install git+https://github.com/dfm/acor.git@master
 ```

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ MPI enabled Parallel Tempering MCMC code written in Python.
 
 Please visit http://jellis18.github.io/PTMCMCSampler/ for documentation.
 
+In order for the sampler to run correctly with Python 3 kernels the GitHub version of acor needs to be installed. It can be in stalled with:
+```
+pip install git+https://github.com/dfm/acor.git@master
+```
+
 ## Attribution
 
 If you make use of this code, please cite:


### PR DESCRIPTION
I've made a few changes to the README file. I added an installation section, mostly to mention that the GitHub version of `acor` needs to be used for Python 3 users. 