### PR TITLE
no extra tab at end of lines

### DIFF
--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -662,11 +662,10 @@ class PTSampler(object):
 
             self._chainfile.write('\t'.join(['%22.22f' % (self._chain[ind, kk])
                                              for kk in range(self.ndim)]))
-            self._chainfile.write('\t%f\t %f\t %f\t %f\t' % (self._lnprob[ind],
-                                                             self._lnlike[ind],
-                                                             self.naccepted /
-                                                             iter, pt_acc))
-            self._chainfile.write('\n')
+            self._chainfile.write('\t%f\t%f\t%f\t%f\n' % (self._lnprob[ind],
+                                                          self._lnlike[ind],
+                                                          self.naccepted/iter,
+                                                          pt_acc))
         self._chainfile.close()
 
         #### write jump statistics files ####


### PR DESCRIPTION
Currently, each line in a chain file ends with a tab and newline character: `\t\n`.  This commit removes the extra tab, so lines will read like:

```
[stuff]\t[stuff]\t[stuff]\n
```

When a chain file is loaded with `pandas.read_csv()`, the extra tab is read as an empty column, making the chain file have one more column than it should.  This fix reduces confusion, when using syntax like `chain[:,-4]` to access the extra data at the end of each chain column.

I care because `pandas.read_csv()` is way faster for loading chain files than `numpy.loadtxt()`.