### PR TITLE
Clarify log messages for optional dependencies

### DIFF
--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -9,13 +9,16 @@ from .nutsjump import HMCJump, MALAJump, NUTSJump
 try:
     from mpi4py import MPI
 except ImportError:
-    print("Do not have mpi4py package.")
+    print("Optional mpi4py package is not installed.  MPI support is not available.")
     from . import nompi4py as MPI
 
 try:
     import acor
 except ImportError:
-    print("Do not have acor package")
+    print(
+        "Optional acor package is not installed. Acor is optionally used to calculate the "
+        "effective chain length for output in the chain file."
+    )
     pass
 
 


### PR DESCRIPTION
Clarifying log messages for optional dependencies when not installed.  The intension of the outputs wasn't immediately clear without reading through other sections of the code or referring back to the repo's documentation.