### PR TITLE
Multiple bug fixes / memory usage reduction

### DIFF
--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -421,7 +421,7 @@ class PTSampler(object):
         iter = i0
         self.tstart = time.time()
         runComplete = False
-        Neff = 0
+        # Neff = 0
         while runComplete is False:
             iter += 1
 
@@ -444,15 +444,16 @@ class PTSampler(object):
 
             # stop if reached maximum number of iterations
             if self.MPIrank == 0 and iter >= self.Niter - 1:
+                self._writeToFile(iter)
                 if self.verbose:
                     print("\nRun Complete")
                 runComplete = True
 
-            # stop if reached effective number of samples
-            if self.MPIrank == 0 and int(Neff) > self.neff:
-                if self.verbose:
-                    print("\nRun Complete with {0} effective samples".format(int(Neff)))
-                runComplete = True
+            # # stop if reached effective number of samples
+            # if self.MPIrank == 0 and int(Neff) > self.neff:
+            #     if self.verbose:
+            #         print("\nRun Complete with {0} effective samples".format(int(Neff)))
+            #     runComplete = True
 
             if self.MPIrank == 0 and runComplete:
                 for jj in range(1, self.nchain):
@@ -736,7 +737,7 @@ class PTSampler(object):
         to_save = np.column_stack([self._buffer, self._lnprob[ind_min:ind_max], self._lnlike[ind_min:ind_max],
                                   np.repeat(self.naccepted / iter, self.buffer_size // self.thin), np.repeat(pt_acc, self.buffer_size // self.thin)])
         with open(self.fname, 'a+') as fname:
-            np.savetxt(fname, to_save)
+            np.savetxt(fname, to_save, fmt='%22.22f')
 
         # write jump statistics files ####
 

--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -12,15 +12,6 @@ except ImportError:
     print("Optional mpi4py package is not installed.  MPI support is not available.")
     from . import nompi4py as MPI
 
-try:
-    import acor
-except ImportError:
-    print(
-        "Optional acor package is not installed. Acor is optionally used to calculate the "
-        "effective chain length for output in the chain file."
-    )
-    pass
-
 
 class PTSampler(object):
 
@@ -436,18 +427,18 @@ class PTSampler(object):
             p0, lnlike0, lnprob0 = self.PTMCMCOneStep(p0, lnlike0, lnprob0, iter)
 
             # compute effective number of samples
-            if iter % 1000 == 0 and iter > 2 * self.burn and self.MPIrank == 0:
-                try:
-                    Neff = iter / max(
-                        1,
-                        np.nanmax(
-                            [acor.acor(self._AMbuffer[self.burn : (iter - 1), ii])[0] for ii in range(self.ndim)]
-                        ),
-                    )
-                    # print('\n {0} effective samples'.format(Neff))
-                except NameError:
-                    Neff = 0
-                    pass
+            # if iter % 1000 == 0 and iter > 2 * self.burn and self.MPIrank == 0:
+            #     try:
+            #         Neff = iter / max(
+            #             1,
+            #             np.nanmax(
+            #                 [acor.acor(self._AMbuffer[self.burn : (iter - 1), ii])[0] for ii in range(self.ndim)]
+            #             ),
+            #         )
+            #         # print('\n {0} effective samples'.format(Neff))
+            #     except NameError:
+            #         Neff = 0
+            #         pass
 
             # stop if reached maximum number of iterations
             if self.MPIrank == 0 and iter >= self.Niter - 1:

--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -290,7 +290,6 @@ class PTSampler(object):
 
             # update buffer
             if self.MPIrank == 0:
-                print((iter % self.buffer_size) // self.thin)
                 self._buffer[(iter % self.buffer_size) // self.thin, :] = p0
 
         # write to file
@@ -729,8 +728,6 @@ class PTSampler(object):
 
         ind_min = ((iter - self.buffer_size) // self.thin)
         ind_max = (iter) // self.thin
-        print(ind_min)
-        print(ind_max)
 
         pt_acc = 1
         if self.MPIrank < self.nchain - 1 and self.swapProposed != 0:

--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -500,7 +500,7 @@ class PTSampler(object):
             getCovariance = 0
 
         # update DE buffer
-        if (iter - 1) % self.buffer_size == 0 and (iter - 1) != 0 and self.MPIrank == 0:
+        if (iter - 1) % self.buffer_size // self.thin == 0 and (iter - 1) != 0 and self.MPIrank == 0:
 
             # broadcast to other chains
             [self.comm.send(self._buffer, dest=rank + 1, tag=222) for rank in range(self.nchain - 1)]

--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -165,7 +165,7 @@ class PTSampler(object):
         """
         # get maximum number of iteration
         if maxIter is None and self.MPIrank > 0:
-            maxIter = 2 * Niter
+            maxIter = 4 * Niter
         elif maxIter is None and self.MPIrank == 0:
             maxIter = Niter
 
@@ -368,7 +368,7 @@ class PTSampler(object):
 
         # get maximum number of iteration
         if maxIter is None and self.MPIrank > 0:
-            maxIter = 2 * Niter
+            maxIter = 4 * Niter
         elif maxIter is None and self.MPIrank == 0:
             maxIter = Niter
 


### PR DESCRIPTION
This PR contains several minor changes to code that 

* Adds more samples for hot chains to continue sampling. 
* Some people were seeing this cause the sampler to fail if the hot chains get to 2 * Niter samples before the cold chain gets to Niter.

* Uses `numpy.savetxt` to write at each buffer length
* Combines the two different buffers (DE and AM)
* The full chain is no longer stored unless `dev=True` to save memory
* Buffer now uses `buffer_length / thin` previous samples instead of the most recent (DEbuffer size) unthinned samples.