### PR TITLE
Synchronize swaps, reduce memory used, SeedSequence for random numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist
 *.egg-info
 .vscode
 venv
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ dist
 *.egg-info
 .vscode
 venv
-.DS_Store

--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -146,7 +146,7 @@ class PTSampler(object):
         NUTSweight=20,
         HMCweight=20,
         MALAweight=0,
-        burn=10000,
+        burn=50000,
         HMCstepsize=0.1,
         HMCsteps=300,
         maxIter=None,
@@ -165,7 +165,7 @@ class PTSampler(object):
         """
         # get maximum number of iteration
         if maxIter is None and self.MPIrank > 0:
-            maxIter = 2 * Niter
+            maxIter = Niter
         elif maxIter is None and self.MPIrank == 0:
             maxIter = Niter
 
@@ -368,7 +368,7 @@ class PTSampler(object):
 
         # get maximum number of iteration
         if maxIter is None and self.MPIrank > 0:
-            maxIter = 2 * Niter
+            maxIter = Niter
         elif maxIter is None and self.MPIrank == 0:
             maxIter = Niter
 

--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -87,12 +87,21 @@ class PTSampler(object):
         outDir="./chains",
         verbose=True,
         resume=False,
+        seed=None,
     ):
 
         # MPI initialization
         self.comm = comm
         self.MPIrank = self.comm.Get_rank()
         self.nchain = self.comm.Get_size()
+
+        if self.MPIrank == 0:
+            ss = np.random.SeedSequence(seed)
+            child_seeds = ss.spawn(self.nchain)
+            self.stream = [np.random.default_rng(s) for s in child_seeds]
+        else:
+            self.stream = None
+        self.stream = comm.scatter(self.stream, root=0)
 
         self.ndim = ndim
         self.logl = _function_wrapper(logl, loglargs, loglkwargs)
@@ -567,7 +576,7 @@ class PTSampler(object):
 
             # hastings step
             diff = newlnprob - lnprob0 + qxy
-            if diff > np.log(np.random.rand()):
+            if diff > np.log(self.stream.random()):
 
                 # accept jump
                 p0, lnlike0, lnprob0 = y, newlnlike, newlnprob
@@ -612,7 +621,7 @@ class PTSampler(object):
                 log_acc_ratio += log_Ls[swap_map[swap_chain]] / Ts[swap_chain + 1]
 
                 acc_ratio = np.exp(log_acc_ratio)
-                if np.random.uniform() <= acc_ratio:
+                if self.stream.uniform() <= acc_ratio:
                     swap_map[swap_chain], swap_map[swap_chain + 1] = swap_map[swap_chain + 1], swap_map[swap_chain]
                     self.nswap_accepted += 1
                     self.swapProposed += 1
@@ -771,11 +780,11 @@ class PTSampler(object):
         qxy = 0
 
         # choose group
-        jumpind = np.random.randint(0, len(self.groups))
+        jumpind = self.stream.integers(0, len(self.groups))
         ndim = len(self.groups[jumpind])
 
         # adjust step size
-        prob = np.random.rand()
+        prob = self.stream.random()
 
         # large jump
         if prob > 0.97:
@@ -802,14 +811,14 @@ class PTSampler(object):
         # y = np.dot(self.U.T, x[self.covinds])
 
         # make correlated componentwise adaptive jump
-        ind = np.unique(np.random.randint(0, ndim, 1))
+        ind = np.unique(self.stream.integers(0, ndim, 1))
         neff = len(ind)
         cd = 2.4 / np.sqrt(2 * neff) * scale
 
-        # y[ind] = y[ind] + np.random.randn(neff) * cd * np.sqrt(self.S[ind])
+        # y[ind] = y[ind] + self.stream.standard_normal(neff) * cd * np.sqrt(self.S[ind])
         # q[self.covinds] = np.dot(self.U, y)
         q[self.groups[jumpind]] += (
-            np.random.randn() * cd * np.sqrt(self.S[jumpind][ind]) * self.U[jumpind][:, ind].flatten()
+            self.stream.standard_normal() * cd * np.sqrt(self.S[jumpind][ind]) * self.U[jumpind][:, ind].flatten()
         )
 
         return q, qxy
@@ -833,10 +842,10 @@ class PTSampler(object):
         qxy = 0
 
         # choose group
-        jumpind = np.random.randint(0, len(self.groups))
+        jumpind = self.stream.integers(0, len(self.groups))
 
         # adjust step size
-        prob = np.random.rand()
+        prob = self.stream.random()
 
         # large jump
         if prob > 0.97:
@@ -866,7 +875,7 @@ class PTSampler(object):
         neff = len(ind)
         cd = 2.4 / np.sqrt(2 * neff) * scale
 
-        y[ind] = y[ind] + np.random.randn(neff) * cd * np.sqrt(self.S[jumpind][ind])
+        y[ind] = y[ind] + self.stream.standard_normal(neff) * cd * np.sqrt(self.S[jumpind][ind])
         q[self.groups[jumpind]] = np.dot(self.U[jumpind], y)
 
         return q, qxy
@@ -891,28 +900,28 @@ class PTSampler(object):
         qxy = 0
 
         # choose group
-        jumpind = np.random.randint(0, len(self.groups))
+        jumpind = self.stream.integers(0, len(self.groups))
         ndim = len(self.groups[jumpind])
 
         bufsize = len(self._DEbuffer)
 
         # draw a random integer from 0 - iter
-        mm = np.random.randint(0, bufsize)
-        nn = np.random.randint(0, bufsize)
+        mm = self.stream.integers(0, bufsize)
+        nn = self.stream.integers(0, bufsize)
 
         # make sure mm and nn are not the same iteration
         while mm == nn:
-            nn = np.random.randint(0, bufsize)
+            nn = self.stream.integers(0, bufsize)
 
         # get jump scale size
-        prob = np.random.rand()
+        prob = self.stream.random()
 
         # mode jump
         if prob > 0.5:
             scale = 1.0
 
         else:
-            scale = np.random.rand() * 2.4 / np.sqrt(2 * ndim) * np.sqrt(1 / beta)
+            scale = self.stream.random() * 2.4 / np.sqrt(2 * ndim) * np.sqrt(1 / beta)
 
         for ii in range(ndim):
 
@@ -979,7 +988,7 @@ class PTSampler(object):
 
         # get random integers
         index = np.arange(length)
-        np.random.shuffle(index)
+        self.stream.shuffle(index)
 
         # randomize proposal cycle
         self.randomizedPropCycle = [self.propCycle[ind] for ind in index]
@@ -995,7 +1004,7 @@ class PTSampler(object):
         length = len(self.propCycle)
 
         # call function
-        ind = np.random.randint(0, length)
+        ind = self.stream.integers(0, length)
         q, qxy = self.propCycle[ind](x, iter, 1 / self.temp)
 
         # axuilary jump

--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -461,14 +461,7 @@ class PTSampler(object):
                     print("\nRun Complete with {0} effective samples".format(int(Neff)))
                 runComplete = True
 
-            if self.MPIrank == 0 and runComplete:
-                for jj in range(1, self.nchain):
-                    self.comm.send(runComplete, dest=jj, tag=55)
-
-            # check for other chains
-            if self.MPIrank > 0:
-                runComplete = self.comm.Iprobe(source=0, tag=55)
-                time.sleep(0.000001)  # trick to get around
+            runComplete = self.comm.bcast(runComplete, root=0)
 
     def PTMCMCOneStep(self, p0, lnlike0, lnprob0, iter):
         """

--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -585,7 +585,7 @@ class PTSampler(object):
                 self.naccepted += 1
                 self.jumpDict[jump_name][1] += 1
         # temperature swap
-        if iter % self.Tskip == 0:
+        if iter % self.Tskip == 0 and self.nchain > 1:
             p0, lnlike0, lnprob0 = self.pt_swap(p0, lnlike0)
         # swapReturn, p0, lnlike0, lnprob0 = self.PTswap(p0, lnlike0, lnprob0, iter)
 

--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -165,7 +165,7 @@ class PTSampler(object):
         """
         # get maximum number of iteration
         if maxIter is None and self.MPIrank > 0:
-            maxIter = 4 * Niter
+            maxIter = Niter
         elif maxIter is None and self.MPIrank == 0:
             maxIter = Niter
 
@@ -368,7 +368,7 @@ class PTSampler(object):
 
         # get maximum number of iteration
         if maxIter is None and self.MPIrank > 0:
-            maxIter = 4 * Niter
+            maxIter = Niter
         elif maxIter is None and self.MPIrank == 0:
             maxIter = Niter
 

--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -97,7 +97,6 @@ class PTSampler(object):
 
         if self.MPIrank == 0:
             ss = np.random.SeedSequence(seed)
-            print(ss.entropy)
             child_seeds = ss.generate_state(self.nchain)
             self.stream = [np.random.default_rng(s) for s in child_seeds]
         else:

--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -165,7 +165,7 @@ class PTSampler(object):
         """
         # get maximum number of iteration
         if maxIter is None and self.MPIrank > 0:
-            maxIter = Niter
+            maxIter = 4 * Niter
         elif maxIter is None and self.MPIrank == 0:
             maxIter = Niter
 
@@ -368,7 +368,7 @@ class PTSampler(object):
 
         # get maximum number of iteration
         if maxIter is None and self.MPIrank > 0:
-            maxIter = Niter
+            maxIter = 4 * Niter
         elif maxIter is None and self.MPIrank == 0:
             maxIter = Niter
 

--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -97,7 +97,8 @@ class PTSampler(object):
 
         if self.MPIrank == 0:
             ss = np.random.SeedSequence(seed)
-            child_seeds = ss.spawn(self.nchain)
+            print(ss.entropy)
+            child_seeds = ss.generate_state(self.nchain)
             self.stream = [np.random.default_rng(s) for s in child_seeds]
         else:
             self.stream = None
@@ -605,8 +606,8 @@ class PTSampler(object):
         """
         Ts = self.ladder
 
-        log_Ls = self.comm.allgather(lnlike0)  # list of likelihoods from each chain
-        p0s = self.comm.allgather(p0)  # list of parameter arrays from each chain
+        log_Ls = self.comm.gather(lnlike0, root=0)  # list of likelihoods from each chain
+        p0s = self.comm.gather(p0, root=0)  # list of parameter arrays from each chain
         
         if self.MPIrank == 0:
             # set up map to help keep track of swaps

--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -165,7 +165,7 @@ class PTSampler(object):
         """
         # get maximum number of iteration
         if maxIter is None and self.MPIrank > 0:
-            maxIter = 4 * Niter
+            maxIter = 2 * Niter
         elif maxIter is None and self.MPIrank == 0:
             maxIter = Niter
 
@@ -368,7 +368,7 @@ class PTSampler(object):
 
         # get maximum number of iteration
         if maxIter is None and self.MPIrank > 0:
-            maxIter = 4 * Niter
+            maxIter = 2 * Niter
         elif maxIter is None and self.MPIrank == 0:
             maxIter = Niter
 

--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -431,7 +431,7 @@ class PTSampler(object):
         Neff = 0
         while runComplete is False:
             iter += 1
-
+            self.comm.barrier()  # make sure all processes are at the same iteration
             # call PTMCMCOneStep
             p0, lnlike0, lnprob0 = self.PTMCMCOneStep(p0, lnlike0, lnprob0, iter)
 
@@ -492,7 +492,7 @@ class PTSampler(object):
             [self.comm.send(self.cov, dest=rank + 1, tag=111) for rank in range(self.nchain - 1)]
 
         # check for sent covariance matrix from T = 0 chain
-        getCovariance = self.comm.Iprobe(source=0, tag=111)
+        getCovariance = self.comm.Iprobe(source=0, tag=111)  # NOTE: swap to recv?
         time.sleep(0.000001)
         if getCovariance and self.MPIrank > 0:
             self.cov[:, :] = self.comm.recv(source=0, tag=111)

--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -572,9 +572,6 @@ class PTSampler(object):
                 self.jumpDict[jump_name][1] += 1
 
         # temperature swap
-        # hold chains until they're all ready to attempt a swap
-        # this will simulate synchronous updating (and keep chains from running away...)
-        self.comm.barrier()
         swapReturn, p0, lnlike0, lnprob0 = self.PTswap(p0, lnlike0, lnprob0, iter)
 
         # check return value

--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -572,6 +572,9 @@ class PTSampler(object):
                 self.jumpDict[jump_name][1] += 1
 
         # temperature swap
+        # hold chains until they're all ready to attempt a swap
+        # this will simulate synchronous updating (and keep chains from running away...)
+        self.comm.barrier()
         swapReturn, p0, lnlike0, lnprob0 = self.PTswap(p0, lnlike0, lnprob0, iter)
 
         # check return value

--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -430,9 +430,8 @@ class PTSampler(object):
         runComplete = False
         Neff = 0
         while runComplete is False:
-            if self.MPIrank == 0:
-                iter += 1
-            iter = self.comm.bcast(iter, root=0)
+            iter += 1
+            self.comm.barrier()  # make sure all processes are at the same iteration
             # call PTMCMCOneStep
             p0, lnlike0, lnprob0 = self.PTMCMCOneStep(p0, lnlike0, lnprob0, iter)
 
@@ -608,89 +607,6 @@ class PTSampler(object):
         readyToSwap = 0
         swapAccepted = 0
         swapProposed = 0
-
-        if iter % self.Tskip == 0:
-            swapProposed = 1
-            swapProposed = self.comm.bcast(swapProposed, root=0)
-
-        # propose swap!
-        if self.MPIrank != self.nchain - 2 and swapProposed == 1:
-            print(self.MPIrank, "proposing swap")
-
-            lnlike0 = self.comm.recv(source=self.MPIrank - 1, tag=18)
-            # send current likelihood for swap proposal
-            self.comm.send(lnlike0, dest=self.MPIrank + 1, tag=18)
-
-            # determine if swap was accepted
-            swapAccepted = self.comm.recv(source=self.MPIrank - 1, tag=888)
-
-            # perform swap
-            if swapAccepted:
-
-                # exchange likelihood
-                lnlike0 = self.comm.recv(source=self.MPIrank + 1, tag=18)
-
-                # exchange parameters
-                pnew = np.empty(self.ndim)
-                self.comm.Sendrecv(
-                    p0, dest=self.MPIrank + 1, sendtag=19, recvbuf=pnew, source=self.MPIrank + 1, recvtag=19
-                )
-                p0 = pnew
-
-                # calculate new posterior values
-                lnprob0 = 1 / self.temp * lnlike0 + self.logp(p0)
-
-        # hotter chain decides acceptance
-            # if readyToSwap:
-            print(self.MPIrank, "ready to swap")
-            newlnlike = self.comm.recv(source=self.MPIrank - 1, tag=18)
-
-            # determine if swap is accepted and tell other chain
-            logChainSwap = (1 / self.ladder[self.MPIrank - 1] - 1 / self.ladder[self.MPIrank]) * (
-                lnlike0 - newlnlike
-            )
-
-            if logChainSwap > np.log(np.random.rand()):
-                swapAccepted = 1
-            else:
-                swapAccepted = 0
-
-            # send out result
-            self.comm.send(swapAccepted, dest=self.MPIrank - 1, tag=888)
-
-            # perform swap
-            if swapAccepted:
-
-                # exchange likelihood
-                self.comm.send(lnlike0, dest=self.MPIrank - 1, tag=18)
-                lnlike0 = newlnlike
-
-                # exchange parameters
-                pnew = np.empty(self.ndim)
-                self.comm.Sendrecv(
-                    p0, dest=self.MPIrank - 1, sendtag=19, recvbuf=pnew, source=self.MPIrank - 1, recvtag=19
-                )
-                p0 = pnew
-
-                # calculate new posterior values
-                lnprob0 = 1 / self.temp * lnlike0 + self.logp(p0)
-
-        # Return values for colder chain: 0=nothing happened; 1=swap proposed,
-        # not accepted; 2=swap proposed & accepted
-        if swapProposed:
-            if swapAccepted:
-                swapReturn = 2
-            else:
-                swapReturn = 1
-        else:
-            swapReturn = 0
-        self.comm.barrier()  # wait until we're all here!
-
-        return swapReturn, p0, lnlike0, lnprob0
-
-
-
-
 
         # if Tskip is reached, block until next chain in ladder is ready for
         # swap proposal

--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -22,6 +22,19 @@ except ImportError:
     pass
 
 
+def shift_array(arr, num, fill_value=0.):
+    result = np.empty_like(arr)
+    if num > 0:
+        result[:num] = fill_value
+        result[num:] = arr[:-num]
+    elif num < 0:
+        result[num:] = fill_value
+        result[:num] = arr[-num:]
+    else:
+        result[:] = arr
+    return result
+
+
 class PTSampler(object):
 
     """
@@ -192,9 +205,8 @@ class PTSampler(object):
         self.nswap_accepted = 0
 
         # set up covariance matrix and DE buffers
-        # TODO: better way of allocating this to save memory
         if self.MPIrank == 0:
-            self._AMbuffer = np.zeros((self.Niter, self.ndim))
+            self._AMbuffer = np.zeros((self.covUpdate, self.ndim))
             self._DEbuffer = np.zeros((self.burn, self.ndim))
 
         # ##### setup default jump proposal distributions ##### #
@@ -288,7 +300,7 @@ class PTSampler(object):
         """
         # update buffer
         if self.MPIrank == 0:
-            self._AMbuffer[iter, :] = p0
+            self._AMbuffer[iter % self.covUpdate, :] = p0
 
         # put results into arrays
         if iter % self.thin == 0:
@@ -441,7 +453,7 @@ class PTSampler(object):
                     Neff = iter / max(
                         1,
                         np.nanmax(
-                            [acor.acor(self._AMbuffer[self.burn : (iter - 1), ii])[0] for ii in range(self.ndim)]
+                            [acor.acor(self._chain[self.burn : (iter - 1), ii])[0] for ii in range(self.ndim)]
                         ),
                     )
                     # print('\n {0} effective samples'.format(Neff))
@@ -709,10 +721,10 @@ class PTSampler(object):
             it += 1
             for jj in range(ndim):
 
-                diff[jj] = self._AMbuffer[iter - mem + ii, jj] - self.mu[jj]
+                diff[jj] = self._AMbuffer[ii, jj] - self.mu[jj]
                 self.mu[jj] += diff[jj] / it
 
-            self.M2 += np.outer(diff, (self._AMbuffer[iter - mem + ii, :] - self.mu))
+            self.M2 += np.outer(diff, (self._AMbuffer[ii, :] - self.mu))
 
         self.cov[:, :] = self.M2 / (it - 1)
 
@@ -736,7 +748,8 @@ class PTSampler(object):
 
         """
 
-        self._DEbuffer = self._AMbuffer[iter - burn : iter]
+        self._DEbuffer = shift_array(self._DEbuffer, -len(self._AMbuffer))  # shift DEbuffer to the left
+        self._DEbuffer[-len(self._AMbuffer):] = self._AMbuffer  # add new samples to the new empty spaces
 
     # SCAM jump
     def covarianceJumpProposalSCAM(self, x, iter, beta):

--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -575,7 +575,7 @@ class PTSampler(object):
                 self.jumpDict[jump_name][1] += 1
         # temperature swap
         if iter % self.Tskip == 0 and self.nchain > 1:
-            p0, lnlike0, lnprob0 = self.PTswap(p0, lnlike0)
+            p0, lnlike0, lnprob0 = self.PTswap(p0, lnlike0, lnprob0, iter)
 
         self.updateChains(p0, lnlike0, lnprob0, iter)
 

--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -165,7 +165,7 @@ class PTSampler(object):
         """
         # get maximum number of iteration
         if maxIter is None and self.MPIrank > 0:
-            maxIter = 2 * Niter
+            maxIter = 4 * Niter
         elif maxIter is None and self.MPIrank == 0:
             maxIter = Niter
 
@@ -368,7 +368,7 @@ class PTSampler(object):
 
         # get maximum number of iteration
         if maxIter is None and self.MPIrank > 0:
-            maxIter = 2 * Niter
+            maxIter = 4 * Niter
         elif maxIter is None and self.MPIrank == 0:
             maxIter = Niter
 


### PR DESCRIPTION
The following changes have been made in this branch:

* Chains now stay on the same iteration and swap synchronously from highest temperature to lowest temperature. This resolves the asynchronous swapping issues in the `HyperModel` framework.
* `_AMBuffer` no longer stores the entire chain: instead it stores pieces and those are shifted into `_DEbuffer`
* `np.random.x` functions have now been swapped to the Generator functions recommended in current versions of `numpy`. Uses a `SeedSequence` to generate seeds for each process. In principle, this should solve the issues with reproducibility. However, to fix this for NANOGrav, we would need to adopt a similar procedure in enterprise_extensions and enterprise.