### PR TITLE
Add in additional stubs to mock MPI object and update tests

### DIFF
--- a/PTMCMCSampler/PTMCMCSampler.py
+++ b/PTMCMCSampler/PTMCMCSampler.py
@@ -101,7 +101,7 @@ class PTSampler(object):
             self.stream = [np.random.default_rng(s) for s in child_seeds]
         else:
             self.stream = None
-        self.stream = comm.scatter(self.stream, root=0)
+        self.stream = self.comm.scatter(self.stream, root=0)
 
         self.ndim = ndim
         self.logl = _function_wrapper(logl, loglargs, loglkwargs)

--- a/PTMCMCSampler/nompi4py.py
+++ b/PTMCMCSampler/nompi4py.py
@@ -21,6 +21,17 @@ class MPIDummy(object):
     def Iprobe(self, source=1, tag=55):
         pass
 
+    def scatter(self, sendobj, **kwargs):
+        if sendobj is not None:
+            return sendobj[0]
+        return None
+
+    def bcast(self, obj, **kwargs):
+        return obj
+
+    def gather(self, sendobj, **kwargs):
+        return [sendobj]
+
 
 # Global object representing no MPI:
 COMM_WORLD = MPIDummy()

--- a/tests/test_nuts.py
+++ b/tests/test_nuts.py
@@ -4,8 +4,10 @@ from unittest import TestCase
 import numpy as np
 import scipy.linalg as sl
 import scipy.optimize as so
+from mpi4py import MPI
 
 from PTMCMCSampler import PTMCMCSampler
+from PTMCMCSampler import nompi4py as MPIDUMMY
 
 
 class GaussianLikelihood(object):
@@ -165,6 +167,9 @@ class TestNuts(TestCase):
     def tearDownClass(cls):
         shutil.rmtree("chains")
 
+    def setUp(self) -> None:
+        self.comm = MPI.COMM_WORLD
+
     def test_nuts(self):
         ndim = 40
         glo = GaussianLikelihood(ndim=ndim, pmin=0.0, pmax=10.0)
@@ -196,6 +201,7 @@ class TestNuts(TestCase):
             logl_grad=gl.lnlikefn_grad,
             logp_grad=gl.lnpriorfn_grad,
             outDir="./chains",
+            comm=self.comm,
         )
 
         sampler.sample(
@@ -213,3 +219,8 @@ class TestNuts(TestCase):
             HMCsteps=100,
             HMCstepsize=0.4,
         )
+
+
+class TestNutsNoMPI(TestNuts):
+    def setUp(self) -> None:
+        self.comm = MPIDUMMY.COMM_WORLD


### PR DESCRIPTION
* Addresses #34 by adding in extra stubs to MPI mock object. Also adds a few smoke tests for to test when no MPI is used.